### PR TITLE
lock the `wp-coding-standards/wpcs` version to 2..x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "squizlabs/php_codesniffer": "@stable",
-    "wp-coding-standards/wpcs": "@stable",
+    "wp-coding-standards/wpcs": "^2.3.0",
     "phpcompatibility/phpcompatibility-wp": "@stable",
     "dealerdirect/phpcodesniffer-composer-installer": "@stable"
   },


### PR DESCRIPTION
This addresses the fact that `@stable` is pulling in breaking changes in the `3.0.0` release. 

Here's a ticket to remind us to update later and check compatibility: #3 