### PR TITLE
Set minimum PHP version to 7.3

### DIFF
--- a/Newfold/ruleset.xml
+++ b/Newfold/ruleset.xml
@@ -5,7 +5,7 @@
     <arg name="colors"/>
 
     <!-- Sets the supported PHP version range. -->
-    <config name="testVersion" value="7.0-"/>
+    <config name="testVersion" value="7.3-"/>
 
     <!-- Sets the minimum supported WP version to 5.8, which requires PHP 5.6+ -->
     <config name="minimum_supported_wp_version" value="5.8"/>


### PR DESCRIPTION
## Proposed changes

Change the minimum PHP version from 7.0 to 7.3 to correspond with the Bluehost plugin PHP version: [composer.json#L17-L19](https://github.com/bluehost/bluehost-wordpress-plugin/blob/a55bce08d3fbd8b877703e134c5db803dbddae1e/composer.json#L17-L19)

So I can add types:

<img width="575" alt="Screenshot 2024-04-22 at 11 51 29 AM" src="https://github.com/newfold-labs/wp-php-standards/assets/4720401/e82a5568-915d-4d1a-b50b-3b0333802532">
