### PR TITLE
Do not exclude tests from `phpcs`/`phpcbf`

### DIFF
--- a/Newfold/ruleset.xml
+++ b/Newfold/ruleset.xml
@@ -15,7 +15,10 @@
 
     <exclude-pattern>*/phpunit.xml*</exclude-pattern>
     <exclude-pattern>*/languages/*</exclude-pattern>
-    <exclude-pattern>*/tests/*</exclude-pattern>
+
+    <exclude-pattern>*/tests/_data/*</exclude-pattern>
+    <exclude-pattern>*/tests/_output/*</exclude-pattern>
+    <exclude-pattern>*/tests/_support/*</exclude-pattern>
 
     <!-- Third-party code -->
     <exclude-pattern>*/bower-components/*</exclude-pattern>


### PR DESCRIPTION
## Proposed changes

Currently, tests do not get auto-formatted by `phpcbf`.

There are many rules that aren't relevant during tests, e.g. suggestions to use WordPress functions which would not be available in PhpUnit tests without WordPress loaded. I already have a list of some, but I'll look up is there a better way to exclude groups of rules than my current one-by-one approach.

## Type of Change

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping

#### Development

- [ ] Tests
- [ ] Dependency update
- [x] Environment update / refactoring
- [ ] Documentation Update

