### PR TITLE
Remove use of `set-output` command

### DIFF
--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -15,11 +15,11 @@ jobs:
         id: package
         env:
           REPO: ${{ github.repository }}
-        run: echo ::set-output name=PACKAGE::${REPO##*/}
+        run: echo "PACKAGE=${REPO##*/}" >> $GITHUB_OUTPUT
 
       - name: Set Version
         id: tag
-        run: echo ::set-output name=VERSION::${GITHUB_REF##*/}
+        run: echo "VERSION=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
 
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v3


### PR DESCRIPTION
## Proposed changes

This removes all occurrences of the `set-output` command from GitHub Actions workflows to ensure workflows continue to work in the future.

This command has [been deprecated by GitHub](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) with [plans to remove it at a future date](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/) when overall usage falls below an acceptable threshold.

See also the [Setting an output parameter section](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#setting-an-output-parameter) of the GitHub Actions documentation.

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [x] Refactoring / housekeeping (changes to files not directly related to functionality)

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update
- [X] Build/Test Tooling update

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
