### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # No GITHUB_TOKEN usage; repository-dispatch uses secrets.WEBHOOK_TOKEN (PAT).
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -14,6 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {} # No GITHUB_TOKEN usage; repository-dispatch uses secrets.WEBHOOK_TOKEN (PAT).
+    timeout-minutes: 30
     steps:
 
       - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 1 (`satis-webhook.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `f7f361c` |
| Timeouts commit | `8cacf2c` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-webhook.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| satis-webhook.yml | 1 job was missing a scoped `permissions:` directive | webhook | `permissions: {}` (no GitHub API calls via `GITHUB_TOKEN`; `peter-evans/repository-dispatch` uses `secrets.WEBHOOK_TOKEN`) [3] |


## Permissions corrections (previously incorrect)

No pre-existing configured `permissions:` were identified as incorrect.

## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| satis-webhook.yml | webhook | `30` | The job only runs short shell steps and one repository-dispatch call; 30 minutes matches the common Actions cap for runaway protection while staying well above expected runtime. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | Verified `peter-evans/repository-dispatch@v4.0.1` (`action.yml`): the `token` input defaults to `${{ github.token }}` but this workflow passes `secrets.WEBHOOK_TOKEN`, so the job does not need `contents: read` or other scopes for that step. There is no `actions/checkout` step. |
| 2 | Local commits used `GIT_COMMIT_GPGSIGN=false` for this environment because GPG signing failed under sandbox restrictions; no `git config` was changed. |


